### PR TITLE
readme: download badge + trim release assets to bat + sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,10 +134,10 @@ jobs:
             exit 1
           fi
 
-      - name: SHA-256 checksums
+      - name: SHA-256 checksum
         if: steps.check.outputs.exists == 'false'
         run: |
-          sha256sum WinMasterBlocker.bat LICENSE CITATION.cff > SHA256SUMS.txt
+          sha256sum WinMasterBlocker.bat > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
       - name: Release notes since previous tag
@@ -166,8 +166,6 @@ jobs:
           body_path: RELEASE_NOTES.md
           files: |
             WinMasterBlocker.bat
-            LICENSE
-            CITATION.cff
             SHA256SUMS.txt
           fail_on_unmatched_files: true
           make_latest: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/ph33nx/WinMasterBlocker/releases/latest/download/WinMasterBlocker.bat"><img src="https://img.shields.io/github/v/release/ph33nx/WinMasterBlocker?label=download&color=brightgreen" alt="Download latest"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/ph33nx/WinMasterBlocker?color=informational" alt="MIT License"></a>
   <a href="https://github.com/ph33nx/WinMasterBlocker/stargazers"><img src="https://img.shields.io/github/stars/ph33nx/WinMasterBlocker?color=yellow" alt="GitHub stars"></a>
   <a href="https://github.com/ph33nx/WinMasterBlocker/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/ph33nx/WinMasterBlocker/ci.yml?branch=main&label=ci" alt="CI status"></a>
@@ -33,7 +34,7 @@ Coverage is two-layered. First a recursive walk of every known install path (`%P
 
 ## Quickstart
 
-1. Download `WinMasterBlocker.bat` from this repo.
+1. Download [WinMasterBlocker.bat](https://github.com/ph33nx/WinMasterBlocker/releases/latest/download/WinMasterBlocker.bat) from the [latest release](https://github.com/ph33nx/WinMasterBlocker/releases/latest). Verify with `certutil -hashfile WinMasterBlocker.bat SHA256` against the `SHA256SUMS.txt` from the same release.
 2. Right-click it, **Run as administrator**. If you double-click, the script re-launches itself with elevation through PowerShell.
 3. Pick a vendor from the menu. Pick `98` after a vendor update to re-scan and add any new executables. Pick `99` to remove every rule the script added.
 


### PR DESCRIPTION
## Summary

- Add a green "download vX.Y.Z" shields.io badge linking directly to `releases/latest/download/WinMasterBlocker.bat` — visible at the top of the README, gives a one-click download path.
- Update Quickstart step 1 to a direct download URL + a checksum verification line (`certutil -hashfile WinMasterBlocker.bat SHA256`).
- Release job now ships only `WinMasterBlocker.bat` + `SHA256SUMS.txt` instead of also bundling `LICENSE` and `CITATION.cff`. Both still live on the repo's main page; bundling them with every release was scope creep. Matches Windows OSS convention (Sysinternals, ShareX).

## Test plan

- [x] No script changes — `lint` / `integration` should pass on touch-only README + workflow edits
- [x] After merge, next `WMB_VERSION` bump publishes a release with just the two assets